### PR TITLE
Improve classpath detection and logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To use this plugin, add the following to your `build.gradle`:
 
 ```groovy
 plugins {
-  id "com.github.mrsarm.jshell.plugin" version "1.1.0"
+  id "com.github.mrsarm.jshell.plugin" version "1.2.0-RC1"
 }
 ```
 
@@ -341,13 +341,15 @@ buildscript {
     }
   }
   dependencies {
-    classpath "com.github.mrsarm:jshell-plugin:1.1.0"
+    classpath "com.github.mrsarm:jshell-plugin:1.2.0-RC1"
   }
 }
 
 apply plugin: "com.github.mrsarm.jshell.plugin"
 ```
 
+Also, when launching the plugin from another project, to see the ":jshell" logs
+add the `--info` argument in the command line, e.g.: `gradle --console plain jshell --info`.
 
 About
 -----
@@ -372,4 +374,4 @@ and this version solves some issues and adds the following features:
 
 ### License
 
- - (2020-2021) [Apache Software License 2.0](https://www.apache.org/licenses/LICENSE-2.0).
+ - (2020-2022) [Apache Software License 2.0](https://www.apache.org/licenses/LICENSE-2.0).

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ To use this plugin, add the following to your `build.gradle`:
 
 ```groovy
 plugins {
-  id "com.github.mrsarm.jshell.plugin" version "1.2.0-RC1"
+  id "com.github.mrsarm.jshell.plugin" version "1.2.0"
 }
 ```
 
@@ -341,7 +341,7 @@ buildscript {
     }
   }
   dependencies {
-    classpath "com.github.mrsarm:jshell-plugin:1.2.0-RC1"
+    classpath "com.github.mrsarm:jshell-plugin:1.2.0"
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group 'com.github.mrsarm'
-version '1.2.0-RC1'
+version '1.2.0-RC2'
 
 sourceCompatibility = 9
 targetCompatibility = 9

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group 'com.github.mrsarm'
-version '1.2.0-RC2'
+version '1.2.0'
 
 sourceCompatibility = 9
 targetCompatibility = 9

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.gradle.plugin-publish' version '0.15.0'
+    id 'com.gradle.plugin-publish' version '0.19.0'
     id 'maven-publish'
     id 'groovy'
     id 'java-library'

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group 'com.github.mrsarm'
-version '1.1.0'
+version '1.2.0-RC1'
 
 sourceCompatibility = 9
 targetCompatibility = 9

--- a/src/main/groovy/com/github/mrsarm/jshell/plugin/JShellPlugin.groovy
+++ b/src/main/groovy/com/github/mrsarm/jshell/plugin/JShellPlugin.groovy
@@ -54,12 +54,12 @@ class JShellPlugin implements Plugin<Project> {
             }
             if (pathSet.isEmpty()) {
                 List<String> classesPaths = project.sourceSets.main.output.getClassesDirs().collect { it.getPath() }
-                jshellTask.logger.info(":jshell couldn't find the classpath, adding " +
+                jshellTask.logger.info(':jshell could not find the classpath, adding ' +
                                        'the following paths from project sourceSets: {}', classesPaths)
                 pathSet.addAll(classesPaths)
                 List<String> depsPaths = project.configurations.compileClasspath.collect { it.getPath() }
                 depsPaths.addAll(project.configurations.runtimeClasspath.collect { it.getPath() })
-                jshellTask.logger.info(":jshell couldn't find the dependencies' classpath, adding " +
+                jshellTask.logger.info(":jshell could not find the dependencies' classpath, adding " +
                                        'the following paths from project configurations: {}', depsPaths)
                 pathSet.addAll(depsPaths)
             }

--- a/src/main/groovy/com/github/mrsarm/jshell/plugin/JShellPlugin.groovy
+++ b/src/main/groovy/com/github/mrsarm/jshell/plugin/JShellPlugin.groovy
@@ -57,7 +57,8 @@ class JShellPlugin implements Plugin<Project> {
                 jshellTask.logger.info(":jshell couldn't find the classpath, adding " +
                                        'the following paths from project sourceSets: {}', classesPaths)
                 pathSet.addAll(classesPaths)
-                List<String> depsPaths = project.configurations.default.collect { it.getPath() }
+                List<String> depsPaths = project.configurations.compileClasspath.collect { it.getPath() }
+                depsPaths.addAll(project.configurations.runtimeClasspath.collect { it.getPath() })
                 jshellTask.logger.info(":jshell couldn't find the dependencies' classpath, adding " +
                                        'the following paths from project configurations: {}', depsPaths)
                 pathSet.addAll(depsPaths)

--- a/src/main/groovy/com/github/mrsarm/jshell/plugin/JShellPlugin.groovy
+++ b/src/main/groovy/com/github/mrsarm/jshell/plugin/JShellPlugin.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020-2021 the original author or authors.
+ * Copyright 2020-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,10 @@ class JShellPlugin implements Plugin<Project> {
         Task jshellTask = project.tasks.create('jshellSetup')
         def classesTask = project.tasks.find { it.name == "classes" }
         if (classesTask) {
+            jshellTask.logger.info 'Task "classes" found.'
             jshellTask.dependsOn classesTask
+        } else {
+            jshellTask.logger.warn 'Task "classes" NOT found.'
         }
         jshellTask.doLast {
             if (!jshellTask.dependsOn) {
@@ -49,15 +52,25 @@ class JShellPlugin implements Plugin<Project> {
                     pathSet.addAll(classpath.findAll { it.exists() })
                 }
             }
+            if (pathSet.isEmpty()) {
+                List<String> classesPaths = project.sourceSets.main.output.getClassesDirs().collect { it.getPath() }
+                jshellTask.logger.info(":jshell couldn't find the classpath, adding " +
+                                       'the following paths from project sourceSets: {}', classesPaths)
+                pathSet.addAll(classesPaths)
+                List<String> depsPaths = project.configurations.default.collect { it.getPath() }
+                jshellTask.logger.info(":jshell couldn't find the dependencies' classpath, adding " +
+                                       'the following paths from project configurations: {}', depsPaths)
+                pathSet.addAll(depsPaths)
+            }
             def path = pathSet.join(System.getProperty("path.separator"))
-            jshellTask.logger.info(":jshell executing with --class-path \"{}\"", path)
+            jshellTask.logger.info(":jshell executing with --class-path {}", path)
             shellArgs += [
                 "--class-path", path,
                 "--startup", "DEFAULT",
                 "--startup", "PRINTING"
             ]
             if (project.findProperty("jshell.startup") == "") {
-                // Nothing, just avoid to run the startup.jsh if exists
+                jshellTask.logger.info ':jshell "jshell.startup" set to empty, skipping "startup.jsh" execution'
             }
             else if (project.findProperty("jshell.startup")) {
                 def jshellStartup = project.findProperty("jshell.startup")


### PR DESCRIPTION
* When classpath is not detected, use alternative sources to get the paths
* Better logging of jshell execution withing the console when `--info` argument is passed
* Minor docs improvement

Issue: #10 