### PR TITLE
Exclude non-jar files

### DIFF
--- a/src/main/groovy/com/github/mrsarm/jshell/plugin/JShellPlugin.groovy
+++ b/src/main/groovy/com/github/mrsarm/jshell/plugin/JShellPlugin.groovy
@@ -65,7 +65,7 @@ class JShellPlugin implements Plugin<Project> {
             }
             
             // Exclude non-directory / non-jar files that jshell doesn't deal with
-            pathSet = pathSet.findAll{ it.isDirectory() || it.toString().endsWith('.jar') }
+            pathSet = pathSet.findAll{ new File(it.toString()).isDirectory() || it.toString().endsWith('.jar') }
             
             def path = pathSet.join(System.getProperty("path.separator"))
             jshellTask.logger.info(":jshell executing with --class-path {}", path)

--- a/src/main/groovy/com/github/mrsarm/jshell/plugin/JShellPlugin.groovy
+++ b/src/main/groovy/com/github/mrsarm/jshell/plugin/JShellPlugin.groovy
@@ -63,6 +63,10 @@ class JShellPlugin implements Plugin<Project> {
                                        'the following paths from project configurations: {}', depsPaths)
                 pathSet.addAll(depsPaths)
             }
+            
+            // Exclude non-directory / non-jar files that jshell doesn't deal with
+            pathSet = pathSet.findAll{ it.isDirectory() || it.toString().endsWith('.jar') }
+            
             def path = pathSet.join(System.getProperty("path.separator"))
             jshellTask.logger.info(":jshell executing with --class-path {}", path)
             shellArgs += [


### PR DESCRIPTION
In large enough projects and for ... reasons, you can sometimes wind up with non-jar files in your classpath. This makes jshell integration slightly easier as jshell is quite vocal about this and quits.